### PR TITLE
fix: updated delete and undelete methods

### DIFF
--- a/app/Models/StorageSystem/FileManager.php
+++ b/app/Models/StorageSystem/FileManager.php
@@ -58,7 +58,7 @@ class FileManager
     public function deleteFile(int $id): void
     {
         // $this->storageFilesRepository->delete($id); // Hard delete
-        $this->storageFilesRepository->setDeleted($id); // Soft delete
+        $this->storageFilesRepository->setDeleted($id, true); // Soft-delete
     }
 
     /**

--- a/app/Models/StorageSystem/Repository/StorageFilesRepository.php
+++ b/app/Models/StorageSystem/Repository/StorageFilesRepository.php
@@ -78,14 +78,18 @@ class StorageFilesRepository
     {
         return $this->db->table(self::TABLE_NAME)
             ->where('id', $id)
-            ->update([$this->db::literal('deleted_at = NOW()')]); // TODO: Check if this works
+            ->update([
+                'deleted_at' => $this->db::literal('NOW()'),
+            ]);
     }
 
     public function setUndelete(int $id): int
     {
         return $this->db->table(self::TABLE_NAME)
             ->where('id', $id)
-            ->update([$this->db::literal('deleted_at = NULL')]); // TODO: Check if this works
+            ->update([
+                'deleted_at' => null,
+            ]);
     }
 
     public function moveToFolder(int $id, int $treeId): int

--- a/app/Models/StorageSystem/Repository/StorageFilesRepository.php
+++ b/app/Models/StorageSystem/Repository/StorageFilesRepository.php
@@ -74,21 +74,14 @@ class StorageFilesRepository
             ->delete();
     }
 
-    public function setDeleted(int $id): int
+    public function setDeleted(int $id, bool $isDeleted): int
     {
         return $this->db->table(self::TABLE_NAME)
             ->where('id', $id)
             ->update([
-                'deleted_at' => $this->db::literal('NOW()'),
-            ]);
-    }
-
-    public function setUndelete(int $id): int
-    {
-        return $this->db->table(self::TABLE_NAME)
-            ->where('id', $id)
-            ->update([
-                'deleted_at' => null,
+                'deleted_at' => $isDeleted
+                    ? $this->db::literal('NOW()')
+                    : null,
             ]);
     }
 

--- a/app/Models/StorageSystem/Repository/StorageTreeRepository.php
+++ b/app/Models/StorageSystem/Repository/StorageTreeRepository.php
@@ -74,21 +74,14 @@ class StorageTreeRepository
             ->delete();
     }
 
-    public function setDeleted(int $id): int
+    public function setDeleted(int $id, bool $isDeleted): int
     {
         return $this->db->table(self::TABLE_NAME)
             ->where('id', $id)
             ->update([
-                'deleted_at' => $this->db::literal('NOW()'),
-            ]);
-    }
-
-    public function setUndelete(int $id): int
-    {
-        return $this->db->table(self::TABLE_NAME)
-            ->where('id', $id)
-            ->update([
-                'deleted_at' => null,
+                'deleted_at' => $isDeleted
+                    ? $this->db::literal('NOW()')
+                    : null,
             ]);
     }
 

--- a/app/Models/StorageSystem/Repository/StorageTreeRepository.php
+++ b/app/Models/StorageSystem/Repository/StorageTreeRepository.php
@@ -78,14 +78,18 @@ class StorageTreeRepository
     {
         return $this->db->table(self::TABLE_NAME)
             ->where('id', $id)
-            ->update([$this->db::literal('deleted_at = NOW()')]); // TODO: Check if this works
+            ->update([
+                'deleted_at' => $this->db::literal('NOW()'),
+            ]);
     }
 
     public function setUndelete(int $id): int
     {
         return $this->db->table(self::TABLE_NAME)
             ->where('id', $id)
-            ->update([$this->db::literal('deleted_at = NULL')]); // TODO: Check if this works
+            ->update([
+                'deleted_at' => null,
+            ]);
     }
 
     public function moveToFolder(int $id, int $parentId): int

--- a/app/Models/StorageSystem/TreeManager.php
+++ b/app/Models/StorageSystem/TreeManager.php
@@ -81,7 +81,7 @@ class TreeManager
     public function deleteFolder(int $id): void
     {
         // $this->storageTreeRepository->delete($id); // Hard delete
-        $this->storageTreeRepository->setDeleted($id); // Soft delete
+        $this->storageTreeRepository->setDeleted($id, true); // Soft-delete
     }
 
     /**
@@ -114,13 +114,11 @@ class TreeManager
      * @param int $treeId The ID of the folder to move.
      * @param int $parentId The ID of the target virtual folder.
      * @param bool $recursive Option to move data recursive (with its content).
-     *
-     * @todo Add option to move folder content recursively
      */
     public function moveToFolder(int $treeId, int $parentId, bool $recursive = true): void
     {
         if ($recursive) {
-            // ...
+            // TODO: Add option to move folder content recursively
         }
 
         $this->storageTreeRepository->moveToFolder($treeId, $parentId);


### PR DESCRIPTION
fix: updated delete and undelete methods to use NOW() and NULL for deleted_at with correct syntax for new Nette version
feat: merge setUndelete into setDeleted in storage repositories